### PR TITLE
Add an extra readout method that uses a firmware patch.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/gerryd/ms213x-status
 go 1.19
 
 require (
-	github.com/BertoldVdb/ms-tools v0.0.0-20231004114646-22ddf782f595
+	github.com/BertoldVdb/ms-tools v0.3.0
 	github.com/alecthomas/kong v0.8.0
 	github.com/google/renameio v1.0.1
 	github.com/sstallion/go-hid v0.14.1

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,9 @@
 github.com/BertoldVdb/ms-tools v0.0.0-20231004114646-22ddf782f595 h1:dUuC+xTDdNG2kl6WF0O4iJKAzabaKhNfedXrdaz6pQs=
 github.com/BertoldVdb/ms-tools v0.0.0-20231004114646-22ddf782f595/go.mod h1:jmbR3cRIFTGz2Licvnbx5fv/SG6aLRJHpOILmEKTy5M=
+github.com/BertoldVdb/ms-tools v0.2.0 h1:uhs8SBnAx1/vlZCN30xk5HwNhOWvjeh56kwUGOCyNl8=
+github.com/BertoldVdb/ms-tools v0.2.0/go.mod h1:4+UR0RlTL4jv4aDXE2SQHdYjbDBiBp1XfvCl8D1qSv8=
+github.com/BertoldVdb/ms-tools v0.3.0 h1:1Xd/HUdgTwlq+C5tsYRX+RqofcuqKpQn/e3JPcDV/tg=
+github.com/BertoldVdb/ms-tools v0.3.0/go.mod h1:4+UR0RlTL4jv4aDXE2SQHdYjbDBiBp1XfvCl8D1qSv8=
 github.com/alecthomas/assert/v2 v2.1.0 h1:tbredtNcQnoSd3QBhQWI7QZ3XHOVkw1Moklp2ojoH/0=
 github.com/alecthomas/kong v0.2.17/go.mod h1:ka3VZ8GZNPXv9Ov+j4YNLkI8mTuhXyr/0ktSlqIydQQ=
 github.com/alecthomas/kong v0.8.0 h1:ryDCzutfIqJPnNn0omnrgHLbAggDQM2VWHikE1xqK7s=
@@ -16,6 +20,7 @@ github.com/mattn/go-colorable v0.1.8/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/sigurn/crc16 v0.0.0-20211026045750-20ab5afb07e3/go.mod h1:9/etS5gpQq9BJsJMWg1wpLbfuSnkm8dPF6FdW2JXVhA=
 github.com/sstallion/go-hid v0.0.0-20190621001400-1cf4630be9f4/go.mod h1:JwBz6izP5UGcbYDU5VGeLkqpRIpSBDPtCB5/XnVXz9Q=
 github.com/sstallion/go-hid v0.14.1 h1:shbZlKqv5fr1KnxwqtLEPGkOoA6OSUWTx9TblegATvc=
 github.com/sstallion/go-hid v0.14.1/go.mod h1:fPKp4rqx0xuoTV94gwKojsPG++KNKhxuU88goGuGM7I=

--- a/status.go
+++ b/status.go
@@ -7,6 +7,7 @@ import (
 
 	"encoding/json"
 
+	"github.com/BertoldVdb/ms-tools/mshal"
 	"github.com/google/renameio"
 )
 
@@ -16,25 +17,26 @@ type Region struct {
 }
 
 type StatusCmd struct {
-	Json      bool   `optional name:"json" help:"Output JSON instead of the default list."`
-	Loop      int    `optional name:"loop" help:"Run in a loop and sleep every N microseconds"`
-	Filename  string `optional name:"filename" help:"Output to a file instead of stdout"`
-	Region    string `optional name:"region" help:"Region to read (murderous, flaky [default], unknown)"`
+	Json     bool   `optional name:"json" help:"Output JSON instead of the default list."`
+	Loop     int    `optional name:"loop" help:"Run in a loop and sleep every N microseconds"`
+	Filename string `optional name:"filename" help:"Output to a file instead of stdout"`
+	Region   string `optional name:"region" help:"Region to read (murderous, flaky [default], unknown)"`
 }
 
 type OutputData struct {
-	Width  int    `json:"width"`
-	Height int    `json:"height"`
-	Signal string `json:"signal"`
-	Time   int64  `json:"time"`
+	Width   int    `json:"width"`
+	Height  int    `json:"height"`
+	Signal  string `json:"signal"`
+	Time    int64  `json:"time"`
+	FrameID int    `json:"fid"`
 }
 
 // the murderous (thanks, Vasil) is always correct, but will every so often kill
 // the device during a read
 func readMurderous(c *Context, output *OutputData) bool {
-	buf := readmem(c, Region { Region: "RAM", Addr: 0x0000e180 }, 16)
+	buf := readmem(c, Region{Region: "RAM", Addr: 0x0000e180}, 16)
 
-	if (len(buf) == 0) {
+	if len(buf) == 0 {
 		return false
 	}
 
@@ -50,11 +52,11 @@ func readMurderous(c *Context, output *OutputData) bool {
 	output.Height = (int(buf[13]) * 256) + int(buf[12])
 
 	// looks like 0x0f/15 means we have an interlaced signal, so we read half the height
-	if (signal == 15) {
+	if signal == 15 {
 		output.Height = 2 * output.Height
 	}
 
-	if (signal > 0 && signal != 8) {
+	if signal > 0 && signal != 8 {
 		output.Signal = "yes"
 	} else {
 		output.Signal = "no"
@@ -65,22 +67,22 @@ func readMurderous(c *Context, output *OutputData) bool {
 
 // the flaky region is always safe to read, but not always correct
 func readFlaky(c *Context, output *OutputData) bool {
-	buf := readmem(c, Region { Region: "RAM", Addr: 0x0000f660 }, 4)
+	buf := readmem(c, Region{Region: "RAM", Addr: 0x0000f660}, 4)
 
-	if (len(buf) == 0) {
+	if len(buf) == 0 {
 		return false
 	}
 
-	output.Width = int(buf[1])*256+int(buf[0])
-	output.Height = int(buf[3])*256+int(buf[2])
+	output.Width = int(buf[1])*256 + int(buf[0])
+	output.Height = int(buf[3])*256 + int(buf[2])
 
-	buf = readmem(c, Region { Region: "RAM", Addr: 0x0000f6e9 }, 1)
+	buf = readmem(c, Region{Region: "RAM", Addr: 0x0000f6e9}, 1)
 
-	if (len(buf) == 0) {
+	if len(buf) == 0 {
 		return false
 	}
 
-	if (buf[0] == 0) {
+	if buf[0] == 0 {
 		output.Signal = "yes"
 	} else {
 		output.Signal = "no"
@@ -92,28 +94,27 @@ func readFlaky(c *Context, output *OutputData) bool {
 // seemingly similar to the flaky region, slight differences though; but not
 // nore correct
 func readUnknown(c *Context, output *OutputData) bool {
-	buf := readmem(c, Region { Region: "RAM", Addr: 0x0000f606 }, 8)
+	buf := readmem(c, Region{Region: "RAM", Addr: 0x0000f606}, 8)
 
-	if (len(buf) == 0) {
+	if len(buf) == 0 {
 		return false
 	}
 
-	output.Width = int(buf[1])*256+int(buf[0])
-	output.Height = int(buf[7])*256+int(buf[6])
+	output.Width = int(buf[1])*256 + int(buf[0])
+	output.Height = int(buf[7])*256 + int(buf[6])
 
 	// signal is the same as flaky for now
-	buf = readmem(c, Region { Region: "RAM", Addr: 0x0000f6e9 }, 1)
+	buf = readmem(c, Region{Region: "RAM", Addr: 0x0000f6e9}, 1)
 
-	if (len(buf) == 0) {
+	if len(buf) == 0 {
 		return false
 	}
 
-	if (buf[0] == 0) {
+	if buf[0] == 0 {
 		output.Signal = "yes"
 	} else {
 		output.Signal = "no"
 	}
-
 
 	return true
 }
@@ -122,6 +123,31 @@ func readFazant(c *Context, output *OutputData) bool {
 	output.Width = 42
 	output.Height = 42
 	output.Signal = "fazantfazantfazant"
+	return true
+}
+
+func readBertold(c *Context, output *OutputData, beforescaler bool) bool { //0xf41e
+	addr := 0xf41e
+	if !beforescaler {
+		addr = 0xf406
+	}
+
+	resp, err := c.hal.PatchExecFunc(true, addr, mshal.PatchExecFuncRequest{})
+	if err != nil {
+		return false
+	}
+
+	output.Width = int(resp.R3)*256 + int(resp.R2)
+	output.Height = int(resp.R5)*256 + int(resp.R4)
+
+	if resp.R6 == 0 {
+		output.Signal = "yes"
+	} else {
+		output.Signal = "no"
+	}
+
+	output.FrameID = int(resp.A)
+
 	return true
 }
 
@@ -135,21 +161,25 @@ func (s *StatusCmd) Run(c *Context) error {
 		read := false
 
 		switch s.Region {
-			case "murderous":
-				read = readMurderous(c, output)
-			case "flaky":
-				read = readFlaky(c, output)
-			case "unknown":
-				read = readUnknown(c, output)
-			case "fazant":
-				read = readFazant(c, output)
-			default:
-				read = readFlaky(c, output)
+		case "murderous":
+			read = readMurderous(c, output)
+		case "flaky":
+			read = readFlaky(c, output)
+		case "unknown":
+			read = readUnknown(c, output)
+		case "fazant":
+			read = readFazant(c, output)
+		case "bertold":
+			read = readBertold(c, output, true)
+		case "bertold_scaler":
+			read = readBertold(c, output, false)
+		default:
+			read = readFlaky(c, output)
 		}
 
-		if (!read) {
+		if !read {
 			// failed read in a loop should just continue and hope...
-			if (s.Loop == 0) {
+			if s.Loop == 0 {
 				fmt.Println("Read nothing from RAM, exiting")
 				os.Exit(1)
 			} else {
@@ -160,20 +190,20 @@ func (s *StatusCmd) Run(c *Context) error {
 
 		var p = ""
 
-		if (s.Json) {
+		if s.Json {
 			data, _ := json.Marshal(output)
 			p = string(data)
 		} else {
-			p = fmt.Sprintf("time: %d\nwidth: %d\nheight: %d\nsignal: %s\n", output.Time, output.Width, output.Height, output.Signal)
+			p = fmt.Sprintf("time: %d\nwidth: %d\nheight: %d\nsignal: %s\nframeid: %d\n", output.Time, output.Width, output.Height, output.Signal, output.FrameID)
 		}
 
-		if (s.Filename == "") {
+		if s.Filename == "" {
 			fmt.Print(p)
 		} else {
 			renameio.WriteFile(s.Filename, []byte(p), os.FileMode(int(0644)))
 		}
 
-		if (s.Loop == 0) {
+		if s.Loop == 0 {
 			next = false
 		} else {
 			time.Sleep(time.Duration(s.Loop) * time.Millisecond)


### PR DESCRIPTION
Hello,

This pull request tries to read the resolution values inside the MS213x firmware. Two new region fields are provided:
bertold -> Resolution on input (might be unstable, running long test now)
bertold_scaler -> Resolution on output of scaler (seems stable for many hours)

These readout methods also provide a counter that is incremented each time a frame is sent. It allows easy detection of freezes.

Good luck.
